### PR TITLE
Add stream to simplify method logic

### DIFF
--- a/src/main/java/ginger/task/TaskHandler.java
+++ b/src/main/java/ginger/task/TaskHandler.java
@@ -57,14 +57,9 @@ public class TaskHandler {
      * @return The task list in a string format.
      */
     public String tasklistToString() {
-        StringBuilder result = new StringBuilder();
-        for (int i = 0; i < taskList.size(); i++) {
-            result.append(String.format("%d. %s", i + 1, taskList.get(i)));
-            if (i != taskList.size() - 1) {
-                result.append("\n");
-            }
-        }
-        return result.toString();
+        return this.taskList.stream()
+                .map(task -> String.format("%d. %s", taskList.indexOf(task) + 1, task))
+                .collect(Collectors.joining("\n"));
     }
 
     /**
@@ -73,14 +68,9 @@ public class TaskHandler {
      * @return The task list in a string format.
      */
     public String tasklistToString(List<Task> taskList) {
-        StringBuilder result = new StringBuilder();
-        for (int i = 0; i < taskList.size(); i++) {
-            result.append(String.format("%d. %s", i + 1, taskList.get(i)));
-            if (i != taskList.size() - 1) {
-                result.append("\n");
-            }
-        }
-        return result.toString();
+        return taskList.stream()
+                .map(task -> String.format("%d. %s", taskList.indexOf(task) + 1, task))
+                .collect(Collectors.joining("\n"));
     }
 
     /**


### PR DESCRIPTION
This PR aims to incorporate streams in some methods.

In particular, it simplifies the logic of displaying a task list, going from appending each task one by one to a StringBuilder to using a stream, mapping each task to a string representation and collecting each task at the end.

This produces shorter code and eliminates the need of a for loop as in the previous iteration.